### PR TITLE
fix: Remove origin alert

### DIFF
--- a/libs/remix-ui/app/src/lib/remix-app/components/modals/origin-warning.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/modals/origin-warning.tsx
@@ -23,11 +23,11 @@ const OriginWarning = () => {
     }
   }, [])
 
-  useEffect(() => {
+  /* useEffect(() => {
     if (content) {
       alert({ id: 'warningOriging', title: null, message: content })
     }
-  }, [content])
+  }, [content]) */
 
   return (<></>)
 }


### PR DESCRIPTION
This PR removes the `remix.ethereum.org` alert that appears when loading from different domain.